### PR TITLE
Feat/mongo 8 upgrade

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -150,6 +150,14 @@ public class MongoSinkTopicConfig extends AbstractConfig {
           + "Requires the 'namespace.mapper' to be set to 'com.mongodb.kafka.connect.sink.topic.mapping.FieldPathNamespaceMapper'.";
   private static final String FIELD_VALUE_COLLECTION_NAMESPACE_MAPPER_DEFAULT = EMPTY_STRING;
 
+  public static final String MANUAL_NAMESPACE_MAPPER_CONFIG = "namespace.mapper.manual.config";
+  private static final String MANUAL_NAMESPACE_MAPPER_DISPLAY =
+      "List of custom mappings for topic to namespace.";
+  private static final String MANUAL_NAMESPACE_MAPPER_DOC =
+      "The mapping array to use as topic to namespace map. "
+          + "Requires the 'namespace.mapper' to be set to 'com.mongodb.kafka.connect.sink.topic.mapping.ManualNamespaceMapper'.";
+  private static final String MANUAL_NAMESPACE_MAPPER_DEFAULT = "";
+
   public static final String FIELD_NAMESPACE_MAPPER_ERROR_IF_INVALID_CONFIG =
       "namespace.mapper.error.if.invalid";
   private static final String FIELD_NAMESPACE_MAPPER_ERROR_IF_INVALID_DISPLAY =
@@ -798,6 +806,16 @@ public class MongoSinkTopicConfig extends AbstractConfig {
         ++orderInGroup,
         ConfigDef.Width.MEDIUM,
         FIELD_VALUE_COLLECTION_NAMESPACE_MAPPER_DISPLAY);
+    configDef.define(
+        MANUAL_NAMESPACE_MAPPER_CONFIG,
+        Type.STRING,
+        MANUAL_NAMESPACE_MAPPER_DEFAULT,
+        ConfigDef.Importance.MEDIUM,
+        MANUAL_NAMESPACE_MAPPER_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.MEDIUM,
+        MANUAL_NAMESPACE_MAPPER_DISPLAY);
     configDef.define(
         FIELD_NAMESPACE_MAPPER_ERROR_IF_INVALID_CONFIG,
         Type.BOOLEAN,

--- a/src/main/java/com/mongodb/kafka/connect/sink/namespace/mapping/ManualNamespaceMapper.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/namespace/mapping/ManualNamespaceMapper.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.sink.namespace.mapping;
+
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.*;
+import static com.mongodb.kafka.connect.util.ConfigHelper.documentFromString;
+import static java.lang.String.format;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import org.bson.Document;
+
+import com.mongodb.MongoNamespace;
+
+import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+import com.mongodb.kafka.connect.util.ConnectConfigException;
+
+public class ManualNamespaceMapper extends FieldPathNamespaceMapper {
+
+  private static final String NAMESPACE_WILDCARD = "*";
+
+  private Map<MongoNamespace, MongoNamespace> namespaceMap;
+
+  @Override
+  public void configure(final MongoSinkTopicConfig config) {
+    super.configure(config);
+    String manualNamespaceMappingString = config.getString(MANUAL_NAMESPACE_MAPPER_CONFIG);
+    this.namespaceMap = new HashMap<>();
+
+    if (manualNamespaceMappingString.isEmpty()) {
+      throw new ConnectConfigException(
+          MANUAL_NAMESPACE_MAPPER_CONFIG,
+          config.getString(MANUAL_NAMESPACE_MAPPER_CONFIG),
+          "Missing configuration for the ManualNamespaceMapper. "
+              + "Please configure the manual namespace mapping.");
+    }
+
+    Optional<Document> manualNamespaceMapping = documentFromString(manualNamespaceMappingString);
+    manualNamespaceMapping.ifPresent(
+        mapping -> {
+          for (Map.Entry<String, Object> ns : mapping.entrySet()) {
+            String oldNamespaceString = ns.getKey();
+            String newNamespaceString = mapping.getString(ns);
+            MongoNamespace oldNamespace = new MongoNamespace(oldNamespaceString);
+            MongoNamespace newNamespace = new MongoNamespace(newNamespaceString);
+            validateNamespaceMapping(oldNamespace, newNamespace);
+            namespaceMap.put(oldNamespace, newNamespace);
+          }
+        });
+  }
+
+  @Override
+  public MongoNamespace getNamespace(final SinkRecord sinkRecord, final SinkDocument sinkDocument) {
+    MongoNamespace targetNamespace = super.getNamespace(sinkRecord, sinkDocument);
+
+    // oldDb.oldColl -> newDb.newColl
+    if (namespaceMap.containsKey(targetNamespace)) {
+      targetNamespace = namespaceMap.get(targetNamespace);
+    } else {
+      // oldDb.* -> newDb.*
+      MongoNamespace collWildcard =
+          new MongoNamespace(targetNamespace.getDatabaseName(), NAMESPACE_WILDCARD);
+      if (namespaceMap.containsKey(collWildcard)) {
+        MongoNamespace wildcardNs = namespaceMap.get(collWildcard);
+        targetNamespace =
+            new MongoNamespace(wildcardNs.getDatabaseName(), targetNamespace.getCollectionName());
+      }
+      // Check for Collection wild cards in mapping
+      // *.oldColl -> *.newColl
+      MongoNamespace dbWildcard =
+          new MongoNamespace(NAMESPACE_WILDCARD, targetNamespace.getCollectionName());
+      if (namespaceMap.containsKey(dbWildcard)) {
+        MongoNamespace wildcardNs = namespaceMap.get(dbWildcard);
+        targetNamespace =
+            new MongoNamespace(targetNamespace.getDatabaseName(), wildcardNs.getCollectionName());
+      }
+    }
+    return targetNamespace;
+  }
+
+  private void validateNamespaceMapping(MongoNamespace oldNs, MongoNamespace newNs) {
+
+    String oldDb = oldNs.getDatabaseName(), oldColl = oldNs.getCollectionName();
+    String newDb = newNs.getDatabaseName(), newColl = newNs.getCollectionName();
+
+    // oldDb.oldColl -> newDb.newColl
+    if (!oldDb.equals(NAMESPACE_WILDCARD)
+        && !newDb.equals(NAMESPACE_WILDCARD)
+        && !oldColl.equals(NAMESPACE_WILDCARD)
+        && !newColl.equals(NAMESPACE_WILDCARD)) return;
+
+    // oldDb.* -> newDb.*
+    if (!oldDb.equals(NAMESPACE_WILDCARD)
+        && !newDb.equals(NAMESPACE_WILDCARD)
+        && oldColl.equals(NAMESPACE_WILDCARD)
+        && newColl.equals(NAMESPACE_WILDCARD)) return;
+
+    // *.oldColl -> *.newColl
+    if (oldDb.equals(NAMESPACE_WILDCARD)
+        && newDb.equals(NAMESPACE_WILDCARD)
+        && !oldColl.equals(NAMESPACE_WILDCARD)
+        && !newColl.equals(NAMESPACE_WILDCARD)) return;
+
+    throw new ConnectConfigException(
+        MANUAL_NAMESPACE_MAPPER_CONFIG,
+        oldNs + "->" + newNs,
+        format(
+            "Invalid mapping : %s -> %s, Allowed patterns are: "
+                + "oldDb.oldColl -> newDb.newColl, "
+                + "oldDb.* -> newDb.*, "
+                + "*.oldColl -> *.newColl",
+            oldNs, newNs));
+  }
+}

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -105,7 +105,7 @@ public final class MongoSourceTask extends SourceTask {
   @SuppressWarnings("try")
   @Override
   public void start(final Map<String, String> props) {
-    LOGGER.info("Starting MongoDB source task");
+    LOGGER.info("Starting MongoDB source task", props);
     StatisticsManager statisticsManager = null;
     MongoClient mongoClient = null;
     MongoCopyDataManager copyDataManager = null;

--- a/src/main/java/com/mongodb/kafka/connect/source/topic/mapping/DefaultTopicMapper.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/topic/mapping/DefaultTopicMapper.java
@@ -158,16 +158,26 @@ public class DefaultTopicMapper implements TopicMapper {
   private String getUndecoratedTopicName(final String dbName, final String collName) {
     assertFalse(dbName.isEmpty());
     String namespace = namespace(dbName, collName);
+
+    // exact match: dbName.collName
     String topicNameTemplate = simplePairs.get(namespace);
     if (topicNameTemplate != null) {
       return topicNameTemplate;
     }
 
+    // partial match: dbName.collName
     topicNameTemplate = simplePairs.get(dbName);
     if (topicNameTemplate != null) {
       return undecoratedTopicName(topicNameTemplate, collName);
     }
 
+    // Wildcard collection match: *.collName
+    topicNameTemplate = simplePairs.get("*" + separator + collName);
+    if (topicNameTemplate != null) {
+      return topicNameTemplate;
+    }
+
+    // Regex pattern match
     String undecoratedTopicName =
         regexPairs.stream()
             .filter(pair -> pair.getKey().reset(namespace).matches())
@@ -178,9 +188,12 @@ public class DefaultTopicMapper implements TopicMapper {
       return undecoratedTopicName;
     }
 
+    // Fallback wildcard topic name
     if (undecoratedWildcardTopicName != null) {
       return undecoratedWildcardTopicName;
     }
+
+    // build topic name using dbName + collName
     return undecoratedTopicName(dbName, collName);
   }
 

--- a/src/test/java/com/mongodb/kafka/connect/source/topic/mapping/DefaultTopicMapperTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/topic/mapping/DefaultTopicMapperTest.java
@@ -314,6 +314,26 @@ public class DefaultTopicMapperTest {
         () -> assertThrows(ConfigException.class, () -> createMapper("{'/[invalid': 'topicOne'}")));
   }
 
+  @Test
+  @DisplayName("test getTopic triggers wildcard collection match (*.collName)")
+  void testGetTopicTriggersWildcardCollectionMatch() {
+    Map<String, String> config = new HashMap<>();
+    config.put(TOPIC_SEPARATOR_CONFIG, ".");
+    config.put(TOPIC_NAMESPACE_MAP_CONFIG, "{'*.myColl': 'wildTopic'}");
+
+    DefaultTopicMapper mapper = new DefaultTopicMapper();
+    mapper.configure(createSourceConfig(config));
+
+    BsonDocument changeStreamDoc =
+        new BsonDocument(
+            "ns",
+            new BsonDocument("db", new BsonString("anyDb"))
+                .append("coll", new BsonString("myColl")));
+
+    String topic = mapper.getTopic(changeStreamDoc);
+    assertEquals("wildTopic", topic);
+  }
+
   private static DefaultTopicMapper createMapper(final MongoSourceConfig config) {
     DefaultTopicMapper topicMapper = new DefaultTopicMapper();
     topicMapper.configure(config);

--- a/src/test/java/com/mongodb/kafka/connect/source/topic/mapping/DefaultTopicMapperTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/topic/mapping/DefaultTopicMapperTest.java
@@ -315,23 +315,34 @@ public class DefaultTopicMapperTest {
   }
 
   @Test
-  @DisplayName("test getTopic triggers wildcard collection match (*.collName)")
-  void testGetTopicTriggersWildcardCollectionMatch() {
+  @DisplayName("getTopic returns wildcard match topic for *.orders mapping")
+  void testGetTopicWithWildcardCollectionMatchReadable() {
+    // Configures: any collection named 'orders' in any DB → goes to 'orders-topic'
     Map<String, String> config = new HashMap<>();
     config.put(TOPIC_SEPARATOR_CONFIG, ".");
-    config.put(TOPIC_NAMESPACE_MAP_CONFIG, "{'*.myColl': 'wildTopic'}");
+    config.put(TOPIC_NAMESPACE_MAP_CONFIG, "{'*.orders': 'orders-topic'}");
 
     DefaultTopicMapper mapper = new DefaultTopicMapper();
     mapper.configure(createSourceConfig(config));
 
-    BsonDocument changeStreamDoc =
+    // Simulate a change stream event from database 'sales' and collection 'orders'
+    // Change stream from sales.orders
+    BsonDocument salesDoc =
         new BsonDocument(
             "ns",
-            new BsonDocument("db", new BsonString("anyDb"))
-                .append("coll", new BsonString("myColl")));
+            new BsonDocument("db", new BsonString("sales"))
+                .append("coll", new BsonString("orders")));
+    // Change stream from users.orders
+    BsonDocument usersDoc =
+        new BsonDocument(
+            "ns",
+            new BsonDocument("db", new BsonString("users"))
+                .append("coll", new BsonString("orders")));
 
-    String topic = mapper.getTopic(changeStreamDoc);
-    assertEquals("wildTopic", topic);
+    // Validate that the topic is resolved to 'orders-topic'
+    // Both should resolve to the same topic
+    assertEquals("orders-topic", mapper.getTopic(salesDoc));
+    assertEquals("orders-topic", mapper.getTopic(usersDoc));
   }
 
   private static DefaultTopicMapper createMapper(final MongoSourceConfig config) {


### PR DESCRIPTION
This PR does the following thing:

* rebase changes.
* adding changes for `getUndecoratedTopicName`  [earlier they were using `getUndecoratedTopicNameFromNamespaceMap`]
* Adding testcase for the above thing.
